### PR TITLE
Update screen.scss

### DIFF
--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -225,6 +225,10 @@ body{
 	    border-radius: 5px;
 
 	}
+	p{
+	    word-wrap: break-word;
+            overflow: hidden;
+	}
 
 }
 .nav-single {
@@ -557,7 +561,6 @@ body{
 
 .hll { background-color: #ffffcc }
 .c { color: #60a0b0; font-style: italic } /* Comment */
-.err { border: 1px solid #FF0000 } /* Error */
 .k { color: #007020; font-weight: bold } /* Keyword */
 .o { color: #666666 } /* Operator */
 .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */


### PR DESCRIPTION
1，避免英文连字挤破布局
2，pygments会自动检测语法错误，多数使用pre的标签较大概率遇到这个问题，默认去掉error的样式。
